### PR TITLE
[MODIFY] 전략 운용종료 로직, 전략승인요청목록 리스팅 로직

### DIFF
--- a/src/main/java/com/sysmatic2/finalbe/admin/repository/StrategyApprovalRequestsRepository.java
+++ b/src/main/java/com/sysmatic2/finalbe/admin/repository/StrategyApprovalRequestsRepository.java
@@ -17,8 +17,10 @@ public interface StrategyApprovalRequestsRepository extends JpaRepository<Strate
     //Pagination 적용한 리스트
     Page<StrategyApprovalRequestsEntity> findAll(Pageable pageable);
 
-    //Pagination 적용, 승인, 승인대기인 요청만 가져오도록
-    Page<StrategyApprovalRequestsEntity> findByIsApprovedIn(List<String> isApprovedList, Pageable pageable);
+    //Pagination 적용, 승인, 승인대기인 요청만 가져오도록, 운용상태코드에 따라
+    Page<StrategyApprovalRequestsEntity> findByIsApprovedInAndStrategy_StrategyStatusCode(List<String> isApprovedList,
+                                                                                           String strategyStatusCode,
+                                                                                           Pageable pageable);
 
 
 

--- a/src/main/java/com/sysmatic2/finalbe/admin/service/StrategyApprovalRequestsService.java
+++ b/src/main/java/com/sysmatic2/finalbe/admin/service/StrategyApprovalRequestsService.java
@@ -43,7 +43,9 @@ public class StrategyApprovalRequestsService {
 
         //페이지 객체를 넣고 요청 엔티티 목록을 가져온다.
         List<String> isApprovedList = Arrays.asList("Y", "P"); //승인, 승인대기인 것만
-        Page<StrategyApprovalRequestsEntity> requestsEntityPage = strategyApprovalRequestsRepository.findByIsApprovedIn(isApprovedList, pageable);
+        Page<StrategyApprovalRequestsEntity> requestsEntityPage =
+                strategyApprovalRequestsRepository.findByIsApprovedInAndStrategy_StrategyStatusCode(isApprovedList,
+                        "STRATEGY_OPERATION_UNDER_MANAGEMENT", pageable);
 
         //엔티티 목록을 dto목록으로 변환한다.
         Page<ApprovalRequestResponseDto> requestResponseDtos = requestsEntityPage.map(DtoEntityConversion::convertToApprovalDto);

--- a/src/main/java/com/sysmatic2/finalbe/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sysmatic2/finalbe/exception/GlobalExceptionHandler.java
@@ -138,7 +138,8 @@ public class GlobalExceptionHandler {
     // 400: 유효성 검사 실패
     @ExceptionHandler({ConstraintViolationException.class, MethodArgumentNotValidException.class,
             InvestmentAssetClassesNotActiveException.class, StrategyAlreadyApprovedException.class,
-            StrategyAlreadyTerminatedException.class, StrategyTerminatedException.class, RequiredAgreementException.class})
+            StrategyAlreadyTerminatedException.class, StrategyTerminatedException.class, RequiredAgreementException.class,
+            StrategyNotApprovedException.class})
     public ResponseEntity<Object> handleValidationExceptions(Exception ex) {
         logger.warn("Validation failed: {}", ex.getMessage());
 
@@ -179,6 +180,11 @@ public class GlobalExceptionHandler {
             RequiredAgreementException requiredAgreementEx = (RequiredAgreementException) ex;
             String field = "memberTerm";
             String message = requiredAgreementEx.getMessage();
+            fieldErrors.put(field, message);
+        } else if (ex instanceof StrategyNotApprovedException) {
+            StrategyNotApprovedException notApprovedEx = (StrategyNotApprovedException) ex;
+            String field = "memberTerm";
+            String message = notApprovedEx.getMessage();
             fieldErrors.put(field, message);
         }
 

--- a/src/main/java/com/sysmatic2/finalbe/exception/StrategyNotApprovedException.java
+++ b/src/main/java/com/sysmatic2/finalbe/exception/StrategyNotApprovedException.java
@@ -1,0 +1,7 @@
+package com.sysmatic2.finalbe.exception;
+
+public class StrategyNotApprovedException extends RuntimeException {
+    public StrategyNotApprovedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sysmatic2/finalbe/strategy/service/StrategyService.java
+++ b/src/main/java/com/sysmatic2/finalbe/strategy/service/StrategyService.java
@@ -1097,6 +1097,11 @@ public class StrategyService {
             throw new StrategyAlreadyTerminatedException("전략이 이미 운용종료된 상태입니다.");
         }
 
+        //승인상태가 P(대기)이거나 N(미승인)인 경우 예외 반환
+        if(strategyEntity.getIsApproved().equals("P") || strategyEntity.getIsApproved().equals("N")) {
+            throw new StrategyNotApprovedException("승인되지 않은 전략입니다.");
+        }
+
         //트레이더면 작성자 판별
         if(isTrader && !strategyEntity.getWriterId().equals(memberId)) {
             throw new AccessDeniedException("운용종료할 권한이 없습니다.");


### PR DESCRIPTION
**바로 머지하지 마세요! 검토 후 머지해야합니다!**

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [X] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
전략 운용종료 로직, 전략승인요청목록 리스팅 로직 수정
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 승인대기, 미승인인 전략은 운용종료 하지 못하도록 변경
2. 승인요청목록에서 전략의 상태가 운용종료인 전략은 보이지 않도록 수정

<br />

## :: 쓰이는 모듈

<br />

## :: 기타 질문 및 특이 사항

